### PR TITLE
fix postgres version to 17

### DIFF
--- a/src/backend/database/Dockerfile
+++ b/src/backend/database/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres
+FROM postgres:17
 WORKDIR .
 # COPY createUser.sql /docker-entrypoint-initdb.d/01.sql    # done through the env vars instead
 COPY ShareShopDB.sql /docker-entrypoint-initdb.d/02.sql


### PR DESCRIPTION
Ab postgres 18 werden die Daten der DB etwas anders gespeichert. Um Probleme zu vermeiden wird die Version auf Version 17 festgelegt.