### PR TITLE
frontend docker setup

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -27,3 +27,9 @@ services:
       start_period: 30s
       timeout: 10s
 
+  frontend:
+    build: frontend/
+    ports:
+      - 8080:80
+    depends_on:
+      - backend

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx
+
+WORKDIR .
+COPY Einkaufsliste/ /usr/share/nginx/html/Einkaufsliste
+COPY Login/ /usr/share/nginx/html/Login
+COPY Startseitendesign/ /usr/share/nginx/html/Startseitendesign
+COPY config-docker.js /usr/share/nginx/html/config.js
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/src/frontend/config-docker.js
+++ b/src/frontend/config-docker.js
@@ -1,0 +1,2 @@
+// config.js
+export const API_BASE_URL = '/api/';

--- a/src/frontend/nginx.conf
+++ b/src/frontend/nginx.conf
@@ -1,0 +1,24 @@
+# 
+upstream backend_upstream{
+    server backend:8001;
+    keepalive 10;
+}
+
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # API proxy. This can be removed if it's not needed
+    # (for example, if proxying is handled outside these containers.
+    # The API path configuration of the frontend needs to be adjusted accordingly)
+
+    location /api/ {
+        proxy_intercept_errors on;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_pass http://backend_upstream/;
+    }
+}


### PR DESCRIPTION
#234 
Kopiert einfach alles wie es ist in den Container und nutzt nur andere Config.  
Aktuell ist damit noch nicht sonderlich viel Nutzbar, was am Stand den Frontends auf dem `develop` branch liegt.  
Es wurden keine Probleme im Frontend selbst behoben (inkonsistente Groß- und Kleinschreibung, Nichtverwenden der API base path Konfiguration).